### PR TITLE
Remove enterprise features from frontend

### DIFF
--- a/enterprise-features.md
+++ b/enterprise-features.md
@@ -1,0 +1,25 @@
+## EnterpriseEditionFeature
+Provides a mapping of all enterprise features available in the project as defined in `packages/frontend/editor-ui/src/constants.ts`.
+These include:
+- advancedExecutionFilters
+- sharing
+- ldap
+- logStreaming
+- variables
+- saml
+- oidc
+- mfaEnforcement
+- sourceControl
+- externalSecrets
+- auditLogs
+- debugInEditor
+- workflowHistory
+- workerView
+- advancedPermissions
+- apiKeyScopes
+
+## isEnterpriseFeatureEnabled
+Located in `packages/frontend/editor-ui/src/utils/rbac/checks/isEnterpriseFeatureEnabled.ts`. Determines if one or more enterprise features are active based on the settings store. Features can be evaluated in `allOf` or `any` mode.
+
+## isEnterpriseFeatureEnabled (settings store)
+Computed property in `packages/frontend/editor-ui/src/stores/settings.store.ts` returning the object that indicates which enterprise features are enabled.

--- a/packages/frontend/editor-ui/src/constants.ts
+++ b/packages/frontend/editor-ui/src/constants.ts
@@ -643,27 +643,10 @@ export const enum WORKFLOW_MENU_ACTIONS {
 /**
  * Enterprise edition
  */
-export const EnterpriseEditionFeature: Record<
-	EnterpriseEditionFeatureKey,
-	EnterpriseEditionFeatureValue
-> = {
-	AdvancedExecutionFilters: 'advancedExecutionFilters',
-	Sharing: 'sharing',
-	Ldap: 'ldap',
-	LogStreaming: 'logStreaming',
-	Variables: 'variables',
-	Saml: 'saml',
-	Oidc: 'oidc',
-	EnforceMFA: 'mfaEnforcement',
-	SourceControl: 'sourceControl',
-	ExternalSecrets: 'externalSecrets',
-	AuditLogs: 'auditLogs',
-	DebugInEditor: 'debugInEditor',
-	WorkflowHistory: 'workflowHistory',
-	WorkerView: 'workerView',
-	AdvancedPermissions: 'advancedPermissions',
-	ApiKeyScopes: 'apiKeyScopes',
-};
+export const EnterpriseEditionFeature = {} as Record<
+       EnterpriseEditionFeatureKey,
+       EnterpriseEditionFeatureValue
+>;
 
 export const MAIN_NODE_PANEL_WIDTH = 390;
 

--- a/packages/frontend/editor-ui/src/stores/settings.store.ts
+++ b/packages/frontend/editor-ui/src/stores/settings.store.ts
@@ -17,6 +17,7 @@ import {
 } from '@/constants';
 import { STORES } from '@n8n/stores';
 import { UserManagementAuthenticationMethod } from '@/Interface';
+import type { EnterpriseEditionFeatureKey } from '@/Interface';
 import type { IDataObject, WorkflowSettings } from 'n8n-workflow';
 import { defineStore } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
@@ -68,7 +69,9 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		secureCookie: settings.value.authCookie.secure,
 	}));
 
-	const isEnterpriseFeatureEnabled = computed(() => settings.value.enterprise);
+       const isEnterpriseFeatureEnabled = computed(
+               () => ({}) as Record<EnterpriseEditionFeatureKey, boolean>,
+       );
 
 	const nodeJsVersion = computed(() => settings.value.nodeJsVersion);
 
@@ -131,9 +134,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 		() => settings.value.telemetry && settings.value.telemetry.enabled,
 	);
 
-	const isMFAEnforcementLicensed = computed(() => {
-		return settings.value.enterprise?.mfaEnforcement ?? false;
-	});
+       const isMFAEnforcementLicensed = computed(() => false);
 
 	const isMfaFeatureEnabled = computed(() => mfa.value.enabled);
 
@@ -166,7 +167,7 @@ export const useSettingsStore = defineStore(STORES.SETTINGS, () => {
 	const isQueueModeEnabled = computed(() => settings.value.executionMode === 'queue');
 	const isMultiMain = computed(() => settings.value.isMultiMain);
 
-	const isWorkerViewAvailable = computed(() => !!settings.value.enterprise?.workerView);
+       const isWorkerViewAvailable = computed(() => false);
 
 	const workflowCallerPolicyDefaultOption = computed(
 		() => settings.value.workflowCallerPolicyDefaultOption,


### PR DESCRIPTION
## Summary
- disable enterprise features in frontend settings
- clear enterprise feature list

## Testing
- `pnpm test` *(fails: registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687538f33a848326a8710a1573970637